### PR TITLE
instance on prepare

### DIFF
--- a/modules/main.js
+++ b/modules/main.js
@@ -39,11 +39,6 @@ async function prepareAuthenticatedCommand(version, forceEnvs = null, dontPrompt
     envs.token = token;
     env.set(envs);
 
-    let opts = await instance(envs, dontPromptLocationPlan);
-    envs.site_name = opts.site_name;
-    envs.instance_type = opts.instance_type;
-    env.set(envs);
-
     envs.version = version;
     envs.files2Ignore = env.extractFiles2Ignore();
 


### PR DESCRIPTION
Hey,

I am using the command line a lot and every commonds takes 2 seconds.
A similar api call is less than 0.5s. I think the cli can be improved to reduce that time. Nodejs is not that bad after all :)

I have just checked quickly and came accross a piece of code that I do not understand the purpose.
By removing it it reduces the reponse time by 25% (0.5s) and looks to provide the same output in the couple of commands I have tested.

Are those couple lines still valid ?
By creating a PR and running the test I might get my answer :)